### PR TITLE
GetStreamURL

### DIFF
--- a/soundcloudapi_test/get_download_url_test.go
+++ b/soundcloudapi_test/get_download_url_test.go
@@ -45,6 +45,18 @@ func TestGetDownloadURLPublic(t *testing.T) {
 	}
 }
 
+func TestGetStreamURL(t *testing.T) {
+	dlURL, err := api.GetStreamURL("https://soundcloud.com/taliya-jenkins/double-cheese-burger-hold-the", "progressive")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+
+	if !strings.Contains(dlURL, "sndcdn.com/") {
+		t.Errorf("Invalid download URL returned, received: (%s)", dlURL)
+	}
+}
+
 func TestGetDownloadURLNewLink(t *testing.T) {
 	// This track has a public download URL link
 	trackInfo, err := api.GetTrackInfo(soundcloudapi.GetTrackInfoOptions{


### PR DESCRIPTION
This extracts GetStreamURL from GetDownloadURL, so you can explicitly get a stream URL even for downloadable tracks. GetDownloadURL still falls back to this if not downloadable.